### PR TITLE
Create container native example

### DIFF
--- a/osbuild/util/ostree.py
+++ b/osbuild/util/ostree.py
@@ -167,6 +167,25 @@ def deployment_path(root: PathLike, osname: str, ref: str, serial: int):
     return sysroot
 
 
+def deployment_path_container(root: PathLike, osname: str, ref: str, serial: int):
+    """Return the path to a deployment given the parameters"""
+
+    base = os.path.join(root, "ostree")
+
+    repo = os.path.join(base, "repo")
+    stateroot = os.path.join(base, "deploy", osname)
+    
+    f = open(f'{root}/tmp/commit.txt', 'r')
+    file_contents = f.read()
+    print (file_contents)
+    sysroot = f"{stateroot}/deploy/{file_contents}.{serial}"
+    f.close()
+    os.remove(f"{root}/tmp/commit.txt")
+    os.rmdir(f"{root}/tmp")
+
+    return sysroot
+
+
 class PasswdLike:
     """Representation of a file with structure like /etc/passwd
 

--- a/stages/org.osbuild.ostree.deploy
+++ b/stages/org.osbuild.ostree.deploy
@@ -28,16 +28,65 @@ from osbuild.util.mnt import MountGuard
 
 CAPABILITIES = ["CAP_MAC_ADMIN"]
 
-SCHEMA_2 = """
-"options": {
-  "additionalProperties": false,
-  "required": ["osname", "ref"],
-  "properties": {
-    "mounts": {
-      "description": "Mount points of the final file system",
-      "type": "array",
-      "items": {
-        "description": "Description of one mount point",
+SCHEMA = """
+"required": ["osname", "rootfs", "ref"],
+"properties": {
+  "mounts": {
+    "description": "Mount points of the final file system",
+    "type": "array",
+    "items": {
+      "description": "Description of one mount point",
+      "type": "string"
+    }
+  },
+  "osname": {
+    "description": "Name of the stateroot to be used in the deployment",
+    "type": "string"
+  },
+  "kernel_opts": {
+    "description": "Additional kernel command line options",
+    "type": "array",
+    "items": {
+      "description": "A single kernel command line option",
+      "type": "string"
+    }
+  },
+  "ref": {
+    "description": "OStree ref to use for the deployment",
+    "type": "string"
+  },
+  "remote": {
+    "description": "optional OStree remote to use for the deployment",
+    "type": "string"
+  },
+  "container": {
+    "description": "Bool to indicate if the deployment is a container",
+    "type": "boolean"
+  },
+  "container-storage": {
+    "type": "object",
+    "properties": {
+      "storage-path": {
+        "description": "Container storage location (default /var/lib/containers/storage).",
+        "type": "string"
+      },
+      "storage-driver": {
+        "description": "The container storage driver to use (default overlay).",
+        "type": "string"
+      }
+    }
+  },
+  "rootfs": {
+    "description": "Identifier to locate the root file system",
+    "type": "object",
+    "oneOf": [{
+      "required": ["uuid"]
+    }, {
+      "required": ["label"]
+    }],
+    "properties": {
+      "label": {
+        "description": "Identify the root file system by label",
         "type": "string"
       }
     },
@@ -110,18 +159,24 @@ def main(tree, options):
     kopts = options.get("kernel_opts", [])
     ref = options["ref"]
     remote = options.get("remote")
-
-    if remote:
-        ref = f"{remote}:{ref}"
+    is_container = options.get("container")
 
     kargs = []
 
-    if rootfs:
-        rootfs_id = make_fs_identifier(rootfs)
-        kargs += [f"--karg=root={rootfs_id}"]
+    if (not is_container):
+      if remote:
+          ref = f"{remote}:{ref}"
 
-    for opt in kopts:
-        kargs += [f"--karg-append={opt}"]
+      if rootfs:
+          rootfs_id = make_fs_identifier(rootfs)
+          kargs += [f"--karg=root={rootfs_id}"]
+
+      for opt in kopts:
+          kargs += [f"--karg-append={opt}"]
+
+    else:
+      for opt in kopts:
+          kargs += [f"--karg={opt}"]
 
     with MountGuard() as mounter:
         for mount in mounts:
@@ -129,11 +184,35 @@ def main(tree, options):
             path = os.path.join(tree, path)
             mounter.mount(path, path)
 
-        ostree("admin", "deploy", ref,
-               *kargs,
-               sysroot=tree,
-               os=osname)
+        if (not is_container):
+          ostree("admin", "deploy", ref,
+                 *kargs,
+                 sysroot=tree,
+                 os=osname)
+        
+        else:
+          # create a temporary directory to store the ostree commit id after deploying the container image
+          os.mkdir(f"{tree}/tmp")
+          
+          # parse and construct the imgref of the container image pulled during the skopeo stage
+          destination = options["container-source"]
+          storage_root = destination.get("storage-path", "/var/lib/containers/storage")
+          storage_driver = destination.get("storage-driver", "overlay")
 
+          imgref = f"{remote}:containers-storage:[{storage_driver}@{tree}{storage_root}+/run/containers/storage]{ref}"
+          
+          extra_args = []
+          if remote:
+              extra_args.append(f'--imgref={imgref}')
+              extra_args.append(f'--stateroot={osname}')
+              extra_args.append(f'--write-commitid-to={tree}/tmp/commit.txt')
+              # hard coded for now, but we can modify it later to take a parameter
+              extra_args.append('--target-imgref=ostree-unverified-registry:quay.io/fedora/fedora-coreos:stable')
+
+          ostree("container", "image", "deploy",
+                *extra_args,
+                sysroot=tree, 
+                *kargs)
 
 if __name__ == '__main__':
     stage_args = osbuild.api.arguments()

--- a/stages/org.osbuild.ostree.selinux
+++ b/stages/org.osbuild.ostree.selinux
@@ -37,21 +37,30 @@ SCHEMA = """
         "default": 0
       }
     }
+  },
+  "container": {
+    "description": "Bool to indicate if the deployment is a container",
+    "type": "boolean"
   }
 }
 """
-
 
 def main(tree, options):
     dep = options["deployment"]
     osname = dep["osname"]
     ref = dep["ref"]
     serial = dep.get("serial", 0)
+    is_container = options.get("container")
 
     # this created a state root at `osname`
     stateroot = f"{tree}/ostree/deploy/{osname}"
 
-    root = ostree.deployment_path(tree, osname, ref, serial)
+    if (not is_container):
+      root = ostree.deployment_path(tree, osname, ref, serial)
+    else:
+      root = ostree.deployment_path_container(tree, osname, ref, serial) 
+    
+    print(root)
 
     # deploying a tree creates new files that need to be properly
     # labeled for SELinux. In theory, ostree will take care of

--- a/test/data/manifests/fedora-coreos-container.mpp.yaml
+++ b/test/data/manifests/fedora-coreos-container.mpp.yaml
@@ -1,0 +1,270 @@
+version: '2'
+mpp-define-image:
+  id: image
+  #10G
+  size: '10737418240'
+  table:
+    uuid: 00000000-0000-4000-a000-000000000001
+    label: gpt
+    partitions:
+      - id: BIOS-BOOT
+        size: 2048
+        type: 21686148-6449-6E6F-744E-656564454649
+        bootable: true
+        uuid: FAC7F1FB-3E8D-4137-A512-961DE09A5549
+      - id: EFI-SYSTEM
+        size: 260096
+        type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+        uuid: 68B2905B-DF3E-4FB3-80FA-49D1E773AA33
+      - id: boot
+        size: 786432
+        type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+        uuid: 61B2905B-DF3E-4FB3-80FA-49D1E773AA32
+      - id: root
+        # XXX: Dynamically set this size in the future
+        size: 8388608
+        type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+        uuid: CA7D7CCB-63ED-4C53-861C-1742536059CC
+# sources:
+#   org.osbuild.skopeo:
+#     items:
+#       sha256:14e9bedf3d4339d7ebeb1d0179d4e8bc11736021e4a9cfe68e728b0087e770f1:
+#         image:
+#           name: quay.io/fedora/fedora-coreos
+#           digest: sha256:0696dd182d2929d3697c0caa191489b88a47d3e1b3921b361961b2af5e1f7988
+#           tls-verify: false
+  # org.osbuild.ostree:
+  #   items:
+  #     d7a91db30c001cb4b354341533ecd71bc308ea4b28e70d30a981f2f7ea3e0b9f:
+  #       remote:
+  #         url: https://kojipkgs.fedoraproject.org/ostree/repo/
+pipelines:
+  - mpp-import-pipelines:
+      path: fedora-vars.ipp.yaml
+  - mpp-import-pipeline:
+      path: fedora-build-v2.ipp.yaml
+      id: build
+    runner:
+      mpp-format-string: org.osbuild.fedora{release}
+  - name: image-tree
+    build: name:build
+    source-epoch: 1659397331
+    stages:
+      - type: org.osbuild.ostree.init-fs
+      - type: org.osbuild.ostree.os-init
+        options:
+          osname: fedora-coreos
+      - type: org.osbuild.ostree.config
+        options:
+          repo: /ostree/repo
+          config:
+            sysroot:
+              readonly: false
+              bootloader: none
+      - type: org.osbuild.mkdir
+        options:
+          paths:
+            - path: /boot/efi
+              mode: 448
+      - type: org.osbuild.skopeo
+        inputs:
+          images:
+            type: org.osbuild.containers
+            origin: org.osbuild.source
+            mpp-resolve-images:
+              images:
+                - source: quay.io/fedora/fedora-coreos
+                  tag: stable
+                  name: localhost/fcos
+        options:
+          destination:
+            type: containers-storage
+            storage-path: /usr/share/containers/storage
+      - type: org.osbuild.ignition
+      - type: org.osbuild.ostree.deploy
+        options:
+          osname: fedora-coreos
+          # The following is where the previous skopeo stage stored the container image:
+          # containers-storage:[overlay@/run/osbuild/tree/usr/share/containers/storage+/run/containers/storage]localhost/fcos
+          ref: localhost/fcos
+          remote: ostree-unverified-image
+          mounts:
+            - /boot
+            - /boot/efi
+          rootfs:
+            label: root
+          # Boolean added to prevent the changes from affecting existing org.ostree.deploy stages
+          container: true
+          # Parameter to find the container image as defined above in the skopeo stage
+          container-source:
+            type: containers-storage
+            storage-path: /usr/share/containers/storage
+          kernel_opts:
+            - rw
+            - console=tty0
+            - console=ttyS0
+            - ignition.platform.id=qemu
+            - '$ignition_firstboot'
+      - type: org.osbuild.ostree.selinux
+        options:
+          deployment:
+            osname: fedora-coreos
+            ref: localhost/fcos
+          container: true
+      - type: org.osbuild.grub2
+        options:
+          rootfs:
+            label: root
+          bootfs:
+            label: boot
+          uefi:
+            vendor: fedora
+            install: true
+          legacy: i386-pc
+          write_defaults: false
+          greenboot: false
+          ignition: true
+  - name: image
+    build: name:build
+    stages:
+      - type: org.osbuild.truncate
+        options:
+          filename: disk.img
+          size:
+            mpp-format-string: '{image.size}'
+      - type: org.osbuild.sfdisk
+        devices:
+          device:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+        options:
+          mpp-format-json: '{image.layout}'
+      - type: org.osbuild.mkfs.fat
+        devices:
+          device:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start:
+                mpp-format-int: '{image.layout[''EFI-SYSTEM''].start}'
+              size:
+                mpp-format-int: '{image.layout[''EFI-SYSTEM''].size}'
+              lock: true
+        options:
+          label: EFI-SYSTEM
+          volid: 7B7795E7
+      - type: org.osbuild.mkfs.ext4
+        devices:
+          device:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start:
+                mpp-format-int: '{image.layout[''boot''].start}'
+              size:
+                mpp-format-int: '{image.layout[''boot''].size}'
+              lock: true
+        options:
+          uuid: 96d15588-3596-4b3c-adca-a2ff7279ea63
+          label: boot
+      - type: org.osbuild.mkfs.xfs
+        devices:
+          device:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start:
+                mpp-format-int: '{image.layout[''root''].start}'
+              size:
+                mpp-format-int: '{image.layout[''root''].size}'
+              lock: true
+        options:
+          uuid: 910678ff-f77e-4a7d-8d53-86f2ac47a823
+          label: root
+      - type: org.osbuild.copy
+        inputs:
+          tree:
+            type: org.osbuild.tree
+            origin: org.osbuild.pipeline
+            references:
+              - name:image-tree
+        options:
+          paths:
+            # skopeo creates a /usr folder in sysroot
+            # only copy the boot and ostree folders
+            - from: input://tree/boot
+              to: mount://root/
+            - from: input://tree/ostree
+              to: mount://root/
+        devices:
+          efi:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start:
+                mpp-format-int: '{image.layout[''EFI-SYSTEM''].start}'
+              size:
+                mpp-format-int: '{image.layout[''EFI-SYSTEM''].size}'
+          boot:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start:
+                mpp-format-int: '{image.layout[''boot''].start}'
+              size:
+                mpp-format-int: '{image.layout[''boot''].size}'
+          root:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start:
+                mpp-format-int: '{image.layout[''root''].start}'
+              size:
+                mpp-format-int: '{image.layout[''root''].size}'
+        mounts:
+          - name: root
+            type: org.osbuild.xfs
+            source: root
+            target: /
+          - name: boot
+            type: org.osbuild.ext4
+            source: boot
+            target: /boot
+          - name: efi
+            type: org.osbuild.fat
+            source: efi
+            target: /boot/efi
+      - type: org.osbuild.grub2.inst
+        options:
+          platform: i386-pc
+          filename: disk.img
+          location:
+            mpp-format-int: '{image.layout[''BIOS-BOOT''].start}'
+          core:
+            type: mkimage
+            partlabel: gpt
+            filesystem: ext4
+          prefix:
+            type: partition
+            partlabel:
+              mpp-format-string: '{image.layout.label}'
+            number:
+              mpp-format-int: '{image.layout[''boot''].index}'
+            path: /grub2
+  - name: qcow2
+    build: name:build
+    stages:
+      - type: org.osbuild.qemu
+        inputs:
+          image:
+            type: org.osbuild.files
+            origin: org.osbuild.pipeline
+            references:
+              name:image:
+                file: disk.img
+        options:
+          filename: disk.qcow2
+          format:
+            type: qcow2
+            compat: '1.1'


### PR DESCRIPTION
Fixes [COS-2387](https://issues.redhat.com/browse/COS-2387)

Created a `fedora-coreos-container.mpp.yaml` example that takes a container image input of FCOS and outputs a `qcow`. Patches were made to existing stages in `osbuild` to accommodate the deployment from a native container image.