### PR TITLE
stages/org.osbuild.gzip: add compression level option

### DIFF
--- a/stages/org.osbuild.gzip
+++ b/stages/org.osbuild.gzip
@@ -30,6 +30,13 @@ SCHEMA_2 = r"""
     "filename": {
       "description": "Filename to use for the compressed file",
       "type": "string"
+    },
+    "level": {
+      "description": "Compression level",
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 9,
+      "default": 1
     }
   }
 }
@@ -48,13 +55,14 @@ def parse_input(inputs):
 
 def main(inputs, output, options):
     filename = options["filename"].lstrip("/")
+    level = options.get("level", 1)
 
     source = parse_input(inputs)
     target = os.path.join(output, filename)
 
     with open(target, "w", encoding="utf8") as f:
         cmd = [
-            "gzip", "--no-name", "--stdout", "-1", source
+            "gzip", "--no-name", "--stdout", f"-{level}", source
         ]
 
         subprocess.run(

--- a/test/data/stages/gzip/b.json
+++ b/test/data/stages/gzip/b.json
@@ -883,7 +883,8 @@
             }
           },
           "options": {
-            "filename": "compressed.gz"
+            "filename": "compressed.gz",
+            "level": 9
           }
         }
       ]

--- a/test/data/stages/gzip/b.mpp.yaml
+++ b/test/data/stages/gzip/b.mpp.yaml
@@ -25,3 +25,4 @@ pipelines:
               sha256:f950375066d74787f31cbd8f9f91c71819357cad243fb9d4a0d9ef4fa76709e0: {}
         options:
           filename: compressed.gz
+          level: 9


### PR DESCRIPTION
Allow compression level to be specified instead of defaulting to 1. This is needed for CoreOS Assembler.

```
$ ls -lh
total 1.8G
-rw-r--r--. 1 root root 921M Feb 21 11:11 compressed-fast.gz
-rw-r--r--. 1 root root 849M Feb 21 11:15 compressed-slow.gz
```